### PR TITLE
fix spelling of GitHub and GitLab

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -23,19 +23,19 @@ probably cannot push or pull using your regular username and password.
 Instead, you may have to create a Personal Access Token (or an App Password in Bitbucket lingo) and use that to authenticate.
 ( [Instructions for GitHub](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)
 | [Instructions for Bitbucket](https://confluence.atlassian.com/bitbucket/app-passwords-828781300.html)
-| [Instructions for Gitlab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
+| [Instructions for GitLab](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html)
 )
 
 ```js
 await git.push({
- username: 'your username', // Note: username is optional for Github
+ username: 'your username', // Note: username is optional for GitHub
  token: 'your Personal Access Token',
  ...
 })
 ```
 
-If you are writing a third-party app that interacts with Github/Gitlab/Bitbucket, you may be obtaining
-OAuth2 tokens from the service via a feature like "Login with Github".
+If you are writing a third-party app that interacts with GitHub/GitLab/Bitbucket, you may be obtaining
+OAuth2 tokens from the service via a feature like "Login with GitHub".
 Depending on the OAuth2 token's grants, you can use those tokens for pushing and pulling from git repos as well.
 Unfortunately, all the major git hosting companies have chosen different conventions for converting
 OAuth2 tokens into Basic Authentication headers! Therefore it is necessary to specify which company's
@@ -68,7 +68,7 @@ A complete summary of how the four parameters interact to determine the Basic Au
 | X        |          |       |              | Error "Missing token or password"                                                |
 |          | X        |       |              | Error "Missing username"                                                         |
 | X        | X        |       |              | `{authUsername: username, authPassword: password}`                               |
-|          |          | X     |              | `{authUsername: token, authPassword: ''}` (Github's alternative format)          |
+|          |          | X     |              | `{authUsername: token, authPassword: ''}` (GitHub's alternative format)          |
 | X        |          | X     |              | `{authUsername: username, authPassword: token}`                                  |
 |          | X        | X     |              | Error "Cannot mix 'password' with 'token'"                                       |
 | X        | X        | X     |              | Error "Cannot mix 'password' with 'token'"                                       |

--- a/docs/guide-browser.md
+++ b/docs/guide-browser.md
@@ -56,7 +56,7 @@ await pfs.readdir(dir);
 Now that we've got an empty directory, let's clone a git repository.
 I'm cloning `isomorphic-git` itself (how meta!).
 I'm only cloning a single branch and only to a depth of 10 commits to save time, bandwidth, and browser storage space.
-Since Github hasn't added CORS headers to the git clone endpoint yet, we have to use a [proxy server](https://cors.isomorphic-git.org/).
+Since GitHub hasn't added CORS headers to the git clone endpoint yet, we have to use a [proxy server](https://cors.isomorphic-git.org/).
 (They never suspected that a *browser* would want to run "git clone"!)
 
 ```js live

--- a/docs/utils_auth.md
+++ b/docs/utils_auth.md
@@ -36,7 +36,7 @@ console.log(credentials)
 credentials = git.utils.auth('username:password')
 console.log(credentials)
 
-// Github/Gitlab Personal Access Token Authentication
+// GitHub/GitLab Personal Access Token Authentication
 credentials = git.utils.auth('username', 'personal access token')
 console.log(credentials)
 
@@ -44,7 +44,7 @@ console.log(credentials)
 credentials = git.utils.auth('username', 'app password')
 console.log(credentials)
 
-// Github (only) lets you leave out the username
+// GitHub (only) lets you leave out the username
 credentials = git.utils.auth('personal access token')
 console.log(credentials)
 ```

--- a/docs/utils_oauth2.md
+++ b/docs/utils_oauth2.md
@@ -19,10 +19,10 @@ This for is for *actual* OAuth2 tokens (not "personal access tokens").
 Unfortunately, all the major git hosting companies have chosen different conventions!
 Lucky for you, I already looked up and codified it for you.
 
-- oauth2('github', token) - Github uses `token` as the username, and `'x-oauth-basic'` as the password.
-- oauth2('githubapp', token) - Github Apps use `'x-access-token'` as the username, and `token` as the password.
+- oauth2('github', token) - GitHub uses `token` as the username, and `'x-oauth-basic'` as the password.
+- oauth2('githubapp', token) - GitHub Apps use `'x-access-token'` as the username, and `token` as the password.
 - oauth2('bitbucket', token) - Bitbucket uses `'x-token-auth'` as the username, and `token` as the password.
-- oauth2('gitlab', token) - Gitlab uses `'oauth2'` as the username, and `token` as the password.
+- oauth2('gitlab', token) - GitLab uses `'oauth2'` as the username, and `token` as the password.
 
 I will gladly accept pull requests for more companies' conventions.
 

--- a/docs/verify.md
+++ b/docs/verify.md
@@ -22,7 +22,7 @@ To use this feature you include openpgp with a separate script tag and pass it i
 
 It is up to you to figure out what the commit's public key should be.
 I would use the "author" or "committer" name and email, and look up
-that person's public key from a trusted source such as the Github API.
+that person's public key from a trusted source such as the GitHub API.
 
 The function returns `false` if any of the signatures on a signed git commit are invalid.
 Otherwise, it returns an array of the key ids that were used to sign it.

--- a/website/i18n/en.json
+++ b/website/i18n/en.json
@@ -76,7 +76,7 @@
     "API Docs": "API Docs",
     "Guide": "Guide",
     "Blog": "Blog",
-    "Github": "Github",
+    "GitHub": "GitHub",
     "npm": "npm",
     "All Commands": "All Commands",
     "Repository": "Repository",

--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -183,7 +183,7 @@ const LearnHow = props => (
     <div style={{ textAlign: 'justify' }}>
       <MarkdownBlock>{`
   isomorphic-git is a pure JavaScript implementation of git that works in node and browser environments (including WebWorkers and ServiceWorkers).
-  This means it can be used to read and write to git repositories, as well as fetch from and push to git remotes like Github.
+  This means it can be used to read and write to git repositories, as well as fetch from and push to git remotes like GitHub.
 
   isomorphic-git aims for 100% interoperability with the canonical git implementation.
   This means it does all its operations by modifying files in a ".git" directory just like the git you are used to.

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -24,7 +24,7 @@ const siteConfig = {
     { blog: true, label: 'Blog' },
     {
       href: 'https://github.com/isomorphic-git/isomorphic-git',
-      label: 'Github'
+      label: 'GitHub'
     },
     {
       href: 'https://npmjs.com/package/isomorphic-git',


### PR DESCRIPTION
the names of these services use camelcase