### PR TITLE
add snippet for git add -A .

### DIFF
--- a/docs/snippets.md
+++ b/docs/snippets.md
@@ -7,7 +7,7 @@ Looking for useful code snippets? Look right here! Have a useful code snippet? A
 
 All snippets are published under the MIT License.
 
-## git add -a
+## git add --no-all .
 
 ```js
 const globby = require('globby');
@@ -15,4 +15,17 @@ const paths = await globby(['./**', './**/.*'], { gitignore: true });
 for (const filepath of paths) {
     await git.add({ fs, dir, filepath });
 }
+```
+
+## git add -A .
+
+```js
+await git.statusMatrix(repo).then((status) =>
+    Promise.all(
+        status.map(([filepath, , worktreeStatus]) =>
+            // isomorphic-git may report a changed file as unmodified, so always add if not removing
+            worktreeStatus ? git.add({ ...repo, filepath }) : git.remove({ ...repo, filepath })
+        );
+    );
+);
 ```


### PR DESCRIPTION
- add snippet for git add -A .
- correctly identify existing snippet as git add --no-all .